### PR TITLE
custom package resolution

### DIFF
--- a/src/Hal/Application/Config/File/AbstractConfigFileReader.php
+++ b/src/Hal/Application/Config/File/AbstractConfigFileReader.php
@@ -44,6 +44,7 @@ abstract class AbstractConfigFileReader implements ConfigFileReaderInterface
             'excludes' => [],
             'report' => [],
             'package-depth' => 0,
+            'package-exclude' => [],
         ];
         /**
          * @var array{
@@ -53,7 +54,8 @@ abstract class AbstractConfigFileReader implements ConfigFileReaderInterface
          *     composer: bool,
          *     searches: array<string, array<string, mixed>>,
          *     excludes: array<string>,
-         *     report: array<string, string>
+         *     report: array<string, string>,
+         *     package-exclude: array<string>
          * } $parsingConfiguration
          */
         $parsingConfiguration = $data + $defaultConfiguration;
@@ -64,6 +66,7 @@ abstract class AbstractConfigFileReader implements ConfigFileReaderInterface
             'extensions' => implode(',', $parsingConfiguration['extensions']),
             'composer' => $parsingConfiguration['composer'],
             'package-depth' => $parsingConfiguration['package-depth'],
+            'package-exclude' => $parsingConfiguration['package-exclude'],
             'searches' => Search::buildListFromArray($parsingConfiguration['searches']),
             'exclude' => implode(',', $parsingConfiguration['excludes']),
             ...array_merge(

--- a/src/Hal/Application/Config/File/AbstractConfigFileReader.php
+++ b/src/Hal/Application/Config/File/AbstractConfigFileReader.php
@@ -43,6 +43,7 @@ abstract class AbstractConfigFileReader implements ConfigFileReaderInterface
             'searches' => [],
             'excludes' => [],
             'report' => [],
+            'package-depth' => 0,
         ];
         /**
          * @var array{
@@ -62,6 +63,7 @@ abstract class AbstractConfigFileReader implements ConfigFileReaderInterface
             'groups' => $parsingConfiguration['groups'],
             'extensions' => implode(',', $parsingConfiguration['extensions']),
             'composer' => $parsingConfiguration['composer'],
+            'package-depth' => $parsingConfiguration['package-depth'],
             'searches' => Search::buildListFromArray($parsingConfiguration['searches']),
             'exclude' => implode(',', $parsingConfiguration['excludes']),
             ...array_merge(

--- a/src/Hal/Application/Config/Validator.php
+++ b/src/Hal/Application/Config/Validator.php
@@ -88,6 +88,11 @@ final class Validator implements ValidatorInterface
         }
         $config->set('composer', filter_var($config->get('composer'), FILTER_VALIDATE_BOOLEAN));
 
+        if (!$config->has('package-depth')) {
+            $config->set('package-depth', 0);
+        }
+        $config->set('package-depth', filter_var($config->get('package-depth'), FILTER_VALIDATE_INT));
+
         // Search
         if (!$config->has('searches')) {
             $config->set('searches', []);

--- a/src/Hal/Application/Config/Validator.php
+++ b/src/Hal/Application/Config/Validator.php
@@ -88,10 +88,16 @@ final class Validator implements ValidatorInterface
         }
         $config->set('composer', filter_var($config->get('composer'), FILTER_VALIDATE_BOOLEAN));
 
+        // Packages
         if (!$config->has('package-depth')) {
             $config->set('package-depth', 0);
         }
         $config->set('package-depth', filter_var($config->get('package-depth'), FILTER_VALIDATE_INT));
+
+        if (!$config->has('package-exclude')) {
+            $config->set('package-exclude', []);
+        }
+        $config->set('package-exclude', array_filter($config->get('package-exclude')));
 
         // Search
         if (!$config->has('searches')) {

--- a/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
+++ b/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
@@ -94,7 +94,7 @@ final class DependencyInjectionProcessor
                 return $app;
             }
 
-            $packageNameExtractor = new PackageNameExtractor(3);
+            $packageNameExtractor = new PackageNameExtractor($config->get('package-depth'));
 
             $metrics = new Metrics();
             $traverser = new NodeTraverser();

--- a/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
+++ b/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
@@ -39,7 +39,7 @@ use Hal\Metric\Package\PackageCollectingVisitor;
 use Hal\Metric\Package\PackageDependencies;
 use Hal\Metric\Package\PackageDistance;
 use Hal\Metric\Package\PackageInstability;
-use Hal\Metric\Package\PackageNameExtractor;
+use Hal\Metric\Package\PackageSieve;
 use Hal\Metric\Searches\Searches;
 use Hal\Metric\System\Coupling\Coupling;
 use Hal\Metric\System\Coupling\DepthOfInheritanceTree;
@@ -94,7 +94,7 @@ final class DependencyInjectionProcessor
                 return $app;
             }
 
-            $packageNameExtractor = new PackageNameExtractor($config->get('package-depth'));
+            $packageSieve = new PackageSieve($config->get('package-depth'));
 
             $metrics = new Metrics();
             $traverser = new NodeTraverser();
@@ -118,7 +118,7 @@ final class DependencyInjectionProcessor
             $traverser->addVisitor(new MaintainabilityIndexVisitor($metrics));
             $traverser->addVisitor(new KanDefectVisitor($metrics, new SimpleNodeIterator()));
             $traverser->addVisitor(new SystemComplexityVisitor($metrics, new SimpleNodeIterator()));
-            $traverser->addVisitor(new PackageCollectingVisitor($metrics, $packageNameExtractor));
+            $traverser->addVisitor(new PackageCollectingVisitor($metrics, $packageSieve));
 
             /**
              * @var array{
@@ -153,7 +153,7 @@ final class DependencyInjectionProcessor
                             new Coupling($metrics),
                             new DepthOfInheritanceTree($metrics),
                             // Package analyses
-                            new PackageDependencies($metrics, $packageNameExtractor),
+                            new PackageDependencies($metrics, $packageSieve),
                             new PackageAbstraction($metrics),
                             new PackageInstability($metrics),
                             new PackageDistance($metrics),

--- a/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
+++ b/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
@@ -94,7 +94,7 @@ final class DependencyInjectionProcessor
                 return $app;
             }
 
-            $packageSieve = new PackageSieve($config->get('package-depth'));
+            $packageSieve = new PackageSieve($config->get('package-depth'), $config->get('package-exclude'));
 
             $metrics = new Metrics();
             $traverser = new NodeTraverser();

--- a/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
+++ b/src/Hal/DependencyInjection/DependencyInjectionProcessor.php
@@ -39,6 +39,7 @@ use Hal\Metric\Package\PackageCollectingVisitor;
 use Hal\Metric\Package\PackageDependencies;
 use Hal\Metric\Package\PackageDistance;
 use Hal\Metric\Package\PackageInstability;
+use Hal\Metric\Package\PackageNameExtractor;
 use Hal\Metric\Searches\Searches;
 use Hal\Metric\System\Coupling\Coupling;
 use Hal\Metric\System\Coupling\DepthOfInheritanceTree;
@@ -93,6 +94,8 @@ final class DependencyInjectionProcessor
                 return $app;
             }
 
+            $packageNameExtractor = new PackageNameExtractor(3);
+
             $metrics = new Metrics();
             $traverser = new NodeTraverser();
             // TODO: Maybe use PHP Attributes to leaveNode/enterNode methods on visitor to restrict the execution by
@@ -115,7 +118,7 @@ final class DependencyInjectionProcessor
             $traverser->addVisitor(new MaintainabilityIndexVisitor($metrics));
             $traverser->addVisitor(new KanDefectVisitor($metrics, new SimpleNodeIterator()));
             $traverser->addVisitor(new SystemComplexityVisitor($metrics, new SimpleNodeIterator()));
-            $traverser->addVisitor(new PackageCollectingVisitor($metrics));
+            $traverser->addVisitor(new PackageCollectingVisitor($metrics, $packageNameExtractor));
 
             /**
              * @var array{
@@ -150,7 +153,7 @@ final class DependencyInjectionProcessor
                             new Coupling($metrics),
                             new DepthOfInheritanceTree($metrics),
                             // Package analyses
-                            new PackageDependencies($metrics),
+                            new PackageDependencies($metrics, $packageNameExtractor),
                             new PackageAbstraction($metrics),
                             new PackageInstability($metrics),
                             new PackageDistance($metrics),

--- a/src/Hal/Metric/Package/PackageCollectingVisitor.php
+++ b/src/Hal/Metric/Package/PackageCollectingVisitor.php
@@ -22,8 +22,8 @@ final class PackageCollectingVisitor extends NodeVisitorAbstract
     private string $namespace = '';
 
     public function __construct(
-        private readonly Metrics $metrics,
-        private readonly PackageNameExtractor $nameExtractor,
+        private readonly Metrics      $metrics,
+        private readonly PackageSieve $packageSieve,
     ) {
     }
 
@@ -54,7 +54,11 @@ final class PackageCollectingVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        $package = $this->nameExtractor->getPackageFromNamespace($this->namespace);
+        if ($this->packageSieve->excludePackage($this->namespace . '\\')) {
+            return null;
+        }
+
+        $package = $this->packageSieve->getPackageFromNamespace($this->namespace);
 
         $docBlockText = (string)$node->getDocComment()?->getText();
         if (1 === preg_match('/^\s*\*\s*@package\s+(.*)/m', $docBlockText, $matches)) {

--- a/src/Hal/Metric/Package/PackageCollectingVisitor.php
+++ b/src/Hal/Metric/Package/PackageCollectingVisitor.php
@@ -22,7 +22,8 @@ final class PackageCollectingVisitor extends NodeVisitorAbstract
     private string $namespace = '';
 
     public function __construct(
-        private readonly Metrics $metrics
+        private readonly Metrics $metrics,
+        private readonly PackageNameExtractor $nameExtractor,
     ) {
     }
 
@@ -53,7 +54,7 @@ final class PackageCollectingVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        $package = $this->namespace;
+        $package = $this->nameExtractor->getPackageFromNamespace($this->namespace);
 
         $docBlockText = (string)$node->getDocComment()?->getText();
         if (1 === preg_match('/^\s*\*\s*@package\s+(.*)/m', $docBlockText, $matches)) {

--- a/src/Hal/Metric/Package/PackageDependencies.php
+++ b/src/Hal/Metric/Package/PackageDependencies.php
@@ -10,8 +10,6 @@ use Hal\Metric\Metrics;
 use Hal\Metric\PackageMetric;
 use function array_map;
 use function in_array;
-use function strrev;
-use function strstr;
 
 /**
  * This class registers the dependencies at package level, instead of class level.
@@ -24,7 +22,10 @@ use function strstr;
  */
 final class PackageDependencies implements CalculableInterface
 {
-    public function __construct(private readonly Metrics $metrics)
+    public function __construct(
+        private readonly Metrics $metrics,
+        private readonly PackageNameExtractor $nameExtractor,
+    )
     {
     }
 
@@ -84,8 +85,6 @@ final class PackageDependencies implements CalculableInterface
             return $packageName;
         }
 
-        // Proceed the string in reverse to try to infer the package name.
-        $revPackageName = strstr(strrev($className), '\\');
-        return false !== $revPackageName ? strrev($revPackageName) : '\\';
+        return $this->nameExtractor->getPackageFromClassName($className);
     }
 }

--- a/src/Hal/Metric/Package/PackageNameExtractor.php
+++ b/src/Hal/Metric/Package/PackageNameExtractor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Hal\Metric\Package;
+
+class PackageNameExtractor
+{
+    public function __construct(
+        private readonly int $packageLevelLimit = 0,
+    ) { }
+
+    public function getPackageFromClassName(string $className): string
+    {
+        if (strpos($className, '\\') === false) {
+            return '\\';
+        }
+
+        $parts = explode('\\', $className);
+        array_pop($parts);
+        if ($this->packageLevelLimit > 0) {
+            $parts = array_slice($parts, 0, $this->packageLevelLimit);
+        }
+        return implode('\\', $parts) . '\\';
+    }
+
+    public function getPackageFromNamespace(string $namespace): string
+    {
+        $package = $namespace;
+        if ($this->packageLevelLimit > 1) {
+            $package = implode('\\', array_slice(
+                explode('\\', $namespace),
+                0, $this->packageLevelLimit
+            ));
+        }
+
+        return $package . '\\';
+    }
+}

--- a/src/Hal/Metric/Package/PackageSieve.php
+++ b/src/Hal/Metric/Package/PackageSieve.php
@@ -2,11 +2,23 @@
 
 namespace Hal\Metric\Package;
 
-class PackageNameExtractor
+class PackageSieve
 {
     public function __construct(
         private readonly int $packageLevelLimit = 0,
-    ) { }
+        private readonly array $ignorePrefixes = [ // todo: move to config
+            'Shopware\\Core\\Migration\\V6_3\\',
+            'Shopware\\Core\\Migration\\V6_4\\',
+            'Shopware\\Core\\Migration\\V6_5\\',
+            'Shopware\\Core\\Migration\\V6_6\\',
+            'Shopware\\Core\\Migration\\V6_7\\',
+            'Shopware\\Core\\Framework\\DataAbstractionLayer\\',
+            'Symfony\\',
+            'Doctrine\\',
+        ]
+    )
+    {
+    }
 
     public function getPackageFromClassName(string $className): string
     {
@@ -33,5 +45,16 @@ class PackageNameExtractor
         }
 
         return $package . '\\';
+    }
+
+    public function excludePackage(string $namespace): bool
+    {
+        foreach ($this->ignorePrefixes as $prefix) {
+            if (str_starts_with($namespace, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Hal/Metric/Package/PackageSieve.php
+++ b/src/Hal/Metric/Package/PackageSieve.php
@@ -6,16 +6,7 @@ class PackageSieve
 {
     public function __construct(
         private readonly int $packageLevelLimit = 0,
-        private readonly array $ignorePrefixes = [ // todo: move to config
-            'Shopware\\Core\\Migration\\V6_3\\',
-            'Shopware\\Core\\Migration\\V6_4\\',
-            'Shopware\\Core\\Migration\\V6_5\\',
-            'Shopware\\Core\\Migration\\V6_6\\',
-            'Shopware\\Core\\Migration\\V6_7\\',
-            'Shopware\\Core\\Framework\\DataAbstractionLayer\\',
-            'Symfony\\',
-            'Doctrine\\',
-        ]
+        private readonly array $ignorePrefixes = [],
     )
     {
     }


### PR DESCRIPTION
- Added configuration option package-depth to make package dependencies report more coarse-grained (0 will switch to default behavior)
- Added configuration option package-exclude to exclude from report namespaces starting with one of provided prefixes (independent from other metrics)